### PR TITLE
GCS Storage Intelligence Version 2.0.0

### DIFF
--- a/views/object_events.view.lkml
+++ b/views/object_events.view.lkml
@@ -20,7 +20,7 @@ view: object_events {
     type: string
     sql:
       CONCAT(
-        CAST(${TABLE}.requestCompletionTime AS STRING), '_',
+        CAST(${TABLE}.requestCompletionTimestamp AS STRING), '_',
         ${TABLE}.requestId, '_',
         ${TABLE}.bucketName
       );;


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/08c7b384-14f4-4e1a-b20c-341e6874b0a9" alt="Cloud Storage Logo Color" height="60" >
   
   # Minor Changes
   - Renaming the ${TABLE}.requestCompletionTime inside views/object_events.view.lkml primary key to ${TABLE}.requestCompletionTimestamp.
